### PR TITLE
Ansible 1.7.0 -> Ansible 2.0.0

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: 'Build and install Ansible Debian package, configure Ansible'
   company: 'DebOps'
   license: 'GNU General Public License v3'
-  min_ansible_version: '1.7.0'
+  min_ansible_version: '2.0.0'
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
As ansible_ssh_user is replaced by ansible_user, minimum Ansible 2.0.0 is required