### PR TITLE
Ansible 1.7.0 -> Ansible 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ enable support for host fact caching in Ansible.
 
 ### Installation
 
-This role requires at least Ansible `v1.7.0`. To install it, run:
+This role requires at least Ansible `v2.0.0`. To install it, run:
 
     ansible-galaxy install debops.ansible
 


### PR DESCRIPTION
As ansible_ssh_user is replaced by ansible_user, minimum Ansible 2.0.0 is required